### PR TITLE
Assert name/short_desc to prevent SHOWALL segfault

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -9239,6 +9239,10 @@ init_custom_variable(const char *name,
 {
 	struct config_generic *gen;
 
+	/* Ensure at least the name and short description are present */
+	Assert(name != NULL);
+	Assert(short_desc != NULL);
+
 	/*
 	 * Only allow custom PGC_POSTMASTER variables to be created during shared
 	 * library preload; any later than that, we can't ensure that the value


### PR DESCRIPTION
[PostgreSQL mailing list thread](https://www.postgresql.org/message-id/CAGRrpzY6hO-Kmykna_XvsTv8P2DshGiU6G3j8yGao4mk0CqjHA%40mail.gmail.com).

Every DefineCustomXXXVariable function can have a NULL short_desc,
and it's not apparent that this will lead to a segfault when SHOW ALL is
used. This happens because ShowAllGUCConfig expects a non-NULL
short_desc.

Assertions are added to init_custom_variable to ensure name and
short_desc are present at minimum.

---

The above segfault happened for Supabase's supautils: https://github.com/supabase/supautils/issues/24

Once this patch is applied, we can build a postgresql with `--enable-cassert` and an error will be reported in case of a short_desc==NULL in `DefineCustomStringVariable`. This can be tested on https://github.com/supabase/supautils/tree/assert-guc:

```
$ nix-shell
$ supautils-with-pg-14 psql

TRAP: FailedAssertion("short_desc != NULL", File: "guc.c", Line: 8906, PID: 345719)
```